### PR TITLE
Bump npm version specified in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "engines": {
     "node": "0.10.x",
-    "npm": "1.2.x"
+    "npm": "2.x"
   }
 }


### PR DESCRIPTION
This is meaningless right now, but it will be useful when we switch to the "yoga" branch of the buildpack which uses this field to install npm.
